### PR TITLE
feat: Add Proxy connection structure from RM to VM with resources 

### DIFF
--- a/src/Resource/proxy.py
+++ b/src/Resource/proxy.py
@@ -1,0 +1,43 @@
+import socket, sys 
+from threading import Thread
+
+# Listening port and the buffer size to get client data
+
+port = 8000 
+buffer_size = 8192
+
+def main():
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        print("Socket initialized")
+        s.bind(('', port))
+        print("Socket binded successfully")
+        # Max connections of 4 TODO what should be the max_connections?
+        s.listen(4)
+    except Exception: 
+        print("Error occured while initializing the socket")
+        sys.exit(1)
+
+    while 1:
+        try:
+            clntConnection, clntAddress = s.accept()
+            clntData = clntConnection.recv(buffer_size).decode()
+            print("Connection from: " + str(clntAddress) + " recieved " + str(clntData))
+
+            # Starting a thread to handle the incoming request
+            (Thread(target = processConnection, args = (clntConnection, clntData, clntAddress))).start()
+        except: 
+            s.close()
+            print('Exitting proxy server')
+            sys.exit(1)
+
+def processConnection(clntConnection, clntData, clntAddress):
+    try:
+        if clntData == 'init':
+            print("Initialize the main resource cluster.")
+        # TODO Implement the proxy handlers for incoming requests
+    except:
+        print("Error occurred in processing the connection string")
+
+if __name__ == '__main__':
+    main()

--- a/src/ResourceManager/RM_management.py
+++ b/src/ResourceManager/RM_management.py
@@ -2,6 +2,11 @@ from fastapi import FastAPI
 from typing import Union
 from pydantic import BaseModel
 from typing import Optional, List
+import socket
+
+proxy_host = "10.140.17.114"
+proxy_port = 8000
+socket = socket.socket()
 
 class Node(BaseModel):
     name: str
@@ -32,6 +37,11 @@ def read_root():
 @app.get("/init/")
 def init():
     # Do all the setup here
+    socket.connect((proxy_host, proxy_port))
+    msg = "init"
+    socket.send(msg.encode())
+    
+    # Should return the proxy response below
     return {"Initializing Setup"}
 
 @app.get("/pods/")
@@ -81,3 +91,16 @@ def delete_node(job_id: int):
     # Make docker cmd call to remove pod
     jobQueue.pop(job_id)
     return {"job": [f"delete job {job_id}\n"]}
+
+def connectThroughProxy():
+    headers = "" # Should define the headers here
+    try:
+        s = socket.socket()
+        s.connect((host,port))
+        s.send(headers.encode('utf-8'))
+        response = s.recv(3000)
+        print (response)
+        s.close()
+    except socket.error as m:
+       print (str(m))
+       s.close() 


### PR DESCRIPTION
Added the proxy connection between RM and the machine that hosts the resource nodes. Added a dummy "init" connection between RM and the proxy server and tested with the user_cli from a third VM. 
The functionalities of other docker commands should be  implemented within this structure. 